### PR TITLE
Skip agents with empty server url.

### DIFF
--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -27,6 +27,7 @@ node['teamcity']['agents'].each do |name, agent| # multiple agents
 
   if agent['server_url'].nil?
     Chef::Log.fatal "You need to setup the server url for agent #{name}"
+    next
   end
 
   # Create the users' group


### PR DESCRIPTION
Skip agents without a server URL to avoid throwing an `undefined method '+' for nil:NilClass` error when building the download URL. Also avoids creating users, groups, ... for invalid agents.
