### PR TITLE
User comment cannot contain colons.

### DIFF
--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -35,7 +35,7 @@ node['teamcity']['agents'].each do |name, agent| # multiple agents
 
   # Create the user
   user agent['user'] do
-    comment 'Team City Agent' + agent_label.call(': ')
+    comment 'TeamCity Agent' + agent_label.call(' ')
     gid agent['group']
     home agent['home']
   end


### PR DESCRIPTION
The useradd command quits with the following:

```
useradd: invalid comment 'Team City Agent: ag1'
```

It works without colon.
