### PR TITLE
Set runtime defaults for non default agents.

### DIFF
--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -29,6 +29,20 @@ node['teamcity']['agents'].each do |name, agent| # multiple agents
     Chef::Log.fatal "You need to setup the server url for agent #{name}"
   end
 
+  # Set runtime specific default values for non default agent
+  agent['user']  ||= 'teamcity'
+  agent['group'] ||= 'teamcity'
+  agent['home']  ||= "/home/" + agent['user']
+  agent['base']  ||= agent['home']
+
+  agent['system_dir'] ||= agent['base']
+  agent['work_dir']   ||= "#{agent['base']}/work"
+  agent['temp_dir']   ||= "#{agent['base']}/tmp"
+  agent['own_port']   ||= 9090
+
+  agent['system_properties'] ||= {}
+  agent['env_properties']    ||= {}
+
   # Create the users' group
   group agent['group'] do
   end


### PR DESCRIPTION
Defaults as stated in README does not work for non default agents. All paths are nil as well as user and group. Also specifying a base path do not expand work or data path. This will fix it. I do not know if there is a more chefy way.
