### PR TITLE
Fix bug that prevents unzip from running when zip file exists.

### DIFF
--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -67,7 +67,7 @@ node['teamcity']['agents'].each do |name, agent| # multiple agents
   execute "unzip #{install_file} -d #{agent[:base]}" do
     user agent[:user]
     creates "#{agent['base']}/bin"
-    not_if { installed_check.call or ::File.exists? install_file }
+    not_if { installed_check.call or not ::File.exists? install_file }
   end
 
   file install_file do


### PR DESCRIPTION
The not_if condition checks if zip file exists. The unzip command
was never run. It was always skiped because the file exists.
