### PR TITLE
Add missing psmisc package

### DIFF
--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -59,6 +59,11 @@ node.teamcity.agents.each do |name, agent| # multiple agents
     not_if &installed_check
   end
 
+  package 'psmisc' do
+    action :install
+    not_if &installed_check
+  end
+
   package 'unzip' do
     action :install
     not_if &installed_check


### PR DESCRIPTION
The psmisc package is required to be able to use fuser in the init.d
script. Without it, chef cannot read the status of the agent and try to
start it at every run.
