### PR TITLE
Update build_query_string to avoid double `??`s

### DIFF
--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -126,8 +126,7 @@ module Teamcity
     def build_query_string(params)
       qs = ''
       params.each do |key,value|
-        qs = "?" if qs.eql? ''
-        qs << "&" unless qs.eql? '?'
+        qs << "&" unless qs.eql? ''
         qs << "#{key}=#{value}"
       end
       qs


### PR DESCRIPTION
Setting `uri.query` adds a `?` character to the URL string automatically.  We don't need to add it again in `build_query_string`, since doing so generates two `?` characters in the URL.
